### PR TITLE
Switch component

### DIFF
--- a/app/Jasonette.xcodeproj/project.pbxproj
+++ b/app/Jasonette.xcodeproj/project.pbxproj
@@ -288,7 +288,6 @@
 		5E0956271DA30970007ADC78 /* Component */ = {
 			isa = PBXGroup;
 			children = (
-				EF8C8CFD1F9195010062CA1C /* switch */,
 				5E2CB5C41D9DF5B600DA2B83 /* JasonComponentFactory.h */,
 				5E2CB5C51D9DF5B600DA2B83 /* JasonComponentFactory.m */,
 				5E09562A1DA33264007ADC78 /* JasonComponentProtocol.h */,
@@ -302,6 +301,7 @@
 				5EE85B701DA486C40049EACE /* textarea */,
 				5EE85B711DA486CA0049EACE /* textfield */,
 				5EE85B721DA486D00049EACE /* slider */,
+				EF8C8CFD1F9195010062CA1C /* switch */,
 				5EE85B731DA486D50049EACE /* html */,
 				5EE85B741DA486DA0049EACE /* space */,
 				5EE85B751DA486DF0049EACE /* map */,

--- a/app/Jasonette/JasonSliderComponent.m
+++ b/app/Jasonette/JasonSliderComponent.m
@@ -14,7 +14,9 @@
     }
     component.continuous = YES;
     component.value = 0.5;
-    component.payload = [@{@"name": json[@"name"], @"action": json[@"action"]} mutableCopy];
+    component.payload = [[NSMutableDictionary alloc] init];
+    if(json && json[@"name"]) component.payload[@"name"] = json[@"name"];
+    if(json && json[@"action"]) component.payload[@"action"] = json[@"action"];
 
     if(options && options[@"value"] && [options[@"value"] length] > 0){
         component.value = [options[@"value"] floatValue];

--- a/app/Jasonette/JasonSwitchComponent.m
+++ b/app/Jasonette/JasonSwitchComponent.m
@@ -21,21 +21,14 @@
     component = [UISwitch new];
   }
   
-  component.payload = [@{@"name": json[@"name"], @"action": json[@"action"]} mutableCopy];
-  
+  component.payload = [[NSMutableDictionary alloc] init];
+  if(json && json[@"name"]) component.payload[@"name"] = json[@"name"];
+  if(json && json[@"action"]) component.payload[@"action"] = json[@"action"];
+
   JasonOptionHelper * data = [[JasonOptionHelper alloc] initWithOptions:options];
   
   BOOL isOn = [data getBoolean:@"value"];
-  
-  if(!isOn)
-  {
-    NSString * value = [data getString:@"value"];
-    if([value isEqualToString:@"true"])
-    {
-      isOn = true;
-    }
-  }
-  
+
   [component setOn:isOn animated:YES];
   
   if(component.isOn)

--- a/app/Jasonette/JasonSwitchComponent.m
+++ b/app/Jasonette/JasonSwitchComponent.m
@@ -65,6 +65,8 @@
     NSString * colorHex = style[@"color:disabled"];
     UIColor * color = [JasonHelper colorwithHexString:colorHex alpha:1.0];
     [component setTintColor:color];
+    [component setBackgroundColor:color];
+    component.layer.cornerRadius = 16;
   }
   
   return component;


### PR DESCRIPTION
1. Moved around the folder so it shows up in an alphabetical order in XCode
2. Did some exception handling for when the user doesn't specify `name` or `action`
3. Made `"color:disabled"` attribute to indicate the background color (as well as the border color) of the disabled state
4. isOn can use boolean values for `true` and `false` (instead of strings like `"true"` and `"false"`) => This is supported as a result of the recent template engine upgrade to ST.js. 

Here are some examples:

- Dynamic rendering with templates: https://jasonbase.com/things/bQp0
- Static view: https://jasonbase.com/things/yKdp

Note how both utilize pure boolean (`true` or `false`) instead of strings (`"true"` or `"false"`)

Please play with it a bit to check that it works fine and pull in the PR if it works. Then I will pull your PR back in from the main Jasonette repo.